### PR TITLE
Avoid shell export errors when existing PATH has spaces

### DIFF
--- a/examples/facestyle/run.sh
+++ b/examples/facestyle/run.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-export PATH=../../bin:$PATH
+export PATH="../../bin:$PATH"
 
 ebsynth -style source_painting.png \
         -guide source_Gapp.png target_Gapp.png -weight 0.5 \


### PR DESCRIPTION
My PATH variable is like: /home/jd/.nvm/versions/node/v13.14.0/bin:/home/jd/.poetry/bin:/opt/GitHub Desktop:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin
with such a PATH, the script would error on startup with message:
./run.sh: 2: export: Desktop:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin: bad variable name