### PR TITLE
Add a Nix Flake as a build system

### DIFF
--- a/build-linux-cpu+cuda.sh
+++ b/build-linux-cpu+cuda.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-nvcc -arch compute_30 src/ebsynth.cpp src/ebsynth_cpu.cpp src/ebsynth_cuda.cu -I"include" -DNDEBUG -D__CORRECT_ISO_CPP11_MATH_H_PROTO -O6 -std=c++11 -w -Xcompiler -fopenmp -o bin/ebsynth
+nvcc --verbose -arch compute_86 src/ebsynth.cpp src/ebsynth_cpu.cpp src/ebsynth_cuda.cu -I"include" -DNDEBUG -D__CORRECT_ISO_CPP11_MATH_H_PROTO -O6 -std=c++11 -w -Xcompiler -fopenmp -o bin/ebsynth

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1686592866,
+        "narHash": "sha256-riGg89eWhXJcPNrQGcSwTEEm7CGxWC06oSX44hajeMw=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "0eeebd64de89e4163f4d3cf34ffe925a5cf67a05",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,26 @@
+{
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+  outputs = { self, nixpkgs }:
+  let
+    pkgs = import nixpkgs { system = "x86_64-linux"; config.allowUnfree = true; };
+  in
+  {
+    packages.x86_64-linux = {
+      default = pkgs.stdenv.mkDerivation {
+        name = "ebsynth";
+        src = ./.;
+        buildInputs = with pkgs; [
+          cudaPackages.cuda_nvcc
+          cudatoolkit
+        ];
+        buildPhase = ''
+          ./build-linux-cpu+cuda.sh
+        '';
+        installPhase = ''
+          mkdir -p $out
+          mv bin $out
+        '';
+      };
+    };
+  };
+}


### PR DESCRIPTION
`nix build` to reproduce on x86. I slightly modified the build script for Linux to be more verbose and target `compute_86` since that's what the latest nvcc requires for this build.